### PR TITLE
Add evaluation notebook

### DIFF
--- a/notebooks/evaluate_model.ipynb
+++ b/notebooks/evaluate_model.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TT-SFUDA Model Evaluation\n",
+    "This notebook demonstrates how to evaluate a pretrained 2D model and visualise its predictions." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import torch\n",
+    "import matplotlib.pyplot as plt\n",
+    "from dataset import Dataset\n",
+    "import archs\n",
+    "from metrics import iou_score\n",
+    "from utils import AverageMeter\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Paths\n",
+    "dataset_name = 'hrf'  # change to your dataset\n",
+    "img_dir = os.path.join('TT_SFUDA_2D', 'inputs', dataset_name, 'images')\n",
+    "mask_dir = os.path.join('TT_SFUDA_2D', 'inputs', dataset_name, 'masks')\n",
+    "img_ids = [os.path.splitext(f)[0] for f in os.listdir(img_dir)]\n",
+    "val_set = Dataset(img_ids, img_dir, mask_dir, '.png', '.png', num_classes=1)\n",
+    "val_loader = torch.utils.data.DataLoader(val_set, batch_size=1, shuffle=False)\n",
+    "\n",
+    "model = archs.UNet(num_classes=1)\n",
+    "model.load_state_dict(torch.load('models/source_model.pth', map_location='cpu'))\n",
+    "model.eval();\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def evaluate(loader, model):\n",
+    "    meter = AverageMeter()\n",
+    "    for img, mask, _ in loader:\n",
+    "        with torch.no_grad():\n",
+    "            output = model(torch.tensor(img))\n",
+    "        _, dice = iou_score(output, torch.tensor(mask))\n",
+    "        meter.update(dice, img.shape[0])\n",
+    "    print('Dice score:', meter.avg)\n",
+    "\n",
+    "evaluate(val_loader, model)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualise a prediction\n",
+    "img, mask, _ = val_set[0]\n",
+    "with torch.no_grad():\n",
+    "    pred = model(torch.tensor(img).unsqueeze(0)).sigmoid()[0,0].numpy()\n",
+    "fig, ax = plt.subplots(1,3, figsize=(12,4))\n",
+    "ax[0].imshow(img.transpose(1,2,0))\n",
+    "ax[0].set_title('Image')\n",
+    "ax[0].axis('off')\n",
+    "ax[1].imshow(mask[0], cmap='gray')\n",
+    "ax[1].set_title('Ground Truth')\n",
+    "ax[1].axis('off')\n",
+    "ax[2].imshow(pred > 0.5, cmap='gray')\n",
+    "ax[2].set_title('Prediction')\n",
+    "ax[2].axis('off')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `evaluate_model.ipynb` with an example workflow for evaluating a pretrained 2D model and visualising predictions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684528da315083238be2423bd443fb81